### PR TITLE
Add support for newer slurm pam module

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ pam_use_sssd: False
 # Enable the pam_slurm.so module
 pam_enable_slurm: False
 
+# Enable the pam_slurm_adopt.so module
+pam_enable_slurm_adopt: False
+
 # These are allowed in /etc/security/access.conf, set when
 # pam_enable_slurm == True
 slurm_access_groups:

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ python3 -m pip install 'molecule[docker]'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  become: True
+  tasks:
+    - name: "Include ansible-role-pam"
+      include_role:
+        name: "ansible-role-pam"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,35 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: noslurm
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+    groups:
+      - pam
+  - name: pam-slurm
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+    groups:
+      - pam
+      - pam_slurm
+  - name: pam-slurm-adopt
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+    groups:
+      - pam
+      - pam_slurm_adopt
+provisioner:
+  name: ansible
+  inventory:
+    group_vars:
+      pam:
+        pam_enabled: True
+      pam_slurm:
+        pam_enable_slurm: True
+      pam_slurm_adopt:
+        pam_enable_slurm_adopt: True
+verifier:
+  name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,34 @@
+---
+- name: Verify pam enabled
+  hosts: all
+  tasks:
+  #- command: cat /etc/pam.d/system-auth
+  #  register: catcmd
+  #- debug:
+  #    var: catcmd.stdout_lines
+  - name: Check whether /etc/pam.d/system-auth is populated
+    command: 'grep "#%PAM-1.0" /etc/pam.d/system-auth'
+
+- name: No slurm pam tests
+  hosts: noslurm
+  tasks:
+  - name: Check that localuser.so is in /etc/pam.d/system-auth
+    command: 'grep "account     sufficient    pam_localuser.so" /etc/pam.d/system-auth'
+  - name: Check that slurm is not mentioned in /etc/pam.d/system-auth
+    command: 'grep -v slurm /etc/pam.d/system-auth'
+
+- name: Slurm pam tests
+  hosts: pam-slurm
+  tasks:
+  - name: Check that localuser.so is in /etc/pam.d/system-auth
+    command: 'grep "account     sufficient    pam_localuser.so" /etc/pam.d/system-auth'
+  - name: Check pam_slurm.so is in /etc/pam.d/system-auth
+    command: 'grep "account     required      pam_slurm.so" /etc/pam.d/system-auth'
+
+- name: Slurm adopt pam tests
+  hosts: pam-slurm-adopt
+  tasks:
+  - name: Check that localuser.so is not in /etc/pam.d/system-auth
+    command: 'grep -v "account     sufficient    pam_localuser.so" /etc/pam.d/system-auth'
+  - name: Check pam_slurm_adopt.so is in /etc/pam.d/system-auth
+    command: 'grep "\-account     sufficient    pam_slurm_adopt.so action_adopt_failure=deny action_generic_failure=deny" /etc/pam.d/system-auth'

--- a/templates/system-auth.j2
+++ b/templates/system-auth.j2
@@ -10,7 +10,9 @@ auth        sufficient    pam_sss.so use_first_pass
 auth        required      pam_deny.so
 
 account     required      pam_unix.so
+{% if not pam_enable_slurm_adopt %}
 account     sufficient    pam_localuser.so
+{% endif %}
 account     sufficient    pam_succeed_if.so uid < 1000 quiet
 {% if pam_use_sssd %}
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
@@ -18,6 +20,9 @@ account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 {% if pam_enable_slurm %}
 account     sufficient    pam_access.so
 account     required      pam_slurm.so
+{% elif pam_enable_slurm_adopt %}
+-account     sufficient    pam_slurm_adopt.so action_adopt_failure=deny action_generic_failure=deny
+account     required      pam_access.so
 {% endif %}
 account     required      pam_permit.so
 
@@ -30,7 +35,9 @@ password    required      pam_deny.so
 
 session     optional      pam_keyinit.so revoke
 session     required      pam_limits.so
+{% if not pam_enable_slurm_adopt %}
 -session     optional      pam_systemd.so
+{% endif %}
 session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
 session     required      pam_unix.so
 {% if pam_use_sssd %}


### PR DESCRIPTION
Slurm has a newer pam module [pam_slurm_adopt.so](https://slurm.schedmd.com/pam_slurm_adopt.html), which enables ssh connections to compute nodes to adopt the cgroups of the running reservations. This PR allows for enabling this module instead of `pam_slurm.so`.

New variables:
- `pam_enable_slurm_adopt` (default: False) : Enables `pam_slurm_adopt.so`. Incompatible with `pam_enable_slurm` (this is not checked in the task). This also disables `pam_localuser.so` and `pam_localuser.so` as they overwrite the module.

New tests:
- There's now [molecule](https://molecule.readthedocs.io/en/latest/) tests that run in Docker and test for these three different cases:
  1. No slurm
  2. `pam_enable_slurm` enabled
  3. `pam_enable_slurm_adopt` enabled

Installation instructions for molecule are included in `molecule/default/INSTALL.rst`.